### PR TITLE
use pg-ctl stop to cleanup before killing the process

### DIFF
--- a/pg_temp/pg_temp.py
+++ b/pg_temp/pg_temp.py
@@ -1,4 +1,5 @@
 """Set up a temporary postgres DB"""
+
 import itertools
 import os
 import sys
@@ -358,6 +359,8 @@ class TempDB(object):
                 stdout=subprocess.DEVNULL,
             )
         elif self.pg_process:
+            pg_stop_cmd = ['pg_ctl', 'stop', '-D', self.pg_data_dir, '-m' 'fast']
+            self.run_cmd(pg_stop_cmd, level=2, bg=True).wait()
             self.pg_process.kill()
             self.pg_process.wait()
         for d in [self.pg_temp_dir]:


### PR DESCRIPTION
Proposed fix for [this issue](https://github.com/ugtar/pg_temp/issues/15)

Ran `make test` to confirm that all existing tests still pass, and `make check` for formatting

[Docs on pg-ctl for reference](https://www.postgresql.org/docs/current/app-pg-ctl.html)